### PR TITLE
Add "allow tap through" option

### DIFF
--- a/lib/onboarding_overlay.dart
+++ b/lib/onboarding_overlay.dart
@@ -3,7 +3,7 @@ library onboarding_overlay;
 export 'src/constants.dart'
     show kOverlayRatio, kLabelBoxWidthRatio, kLabelBoxHeightRatio;
 export 'src/label_painter.dart' show LabelPainter, ArrowPosition;
-export 'src/onboarding_widget.dart' show Onboarding, OnboardingState;
+export 'src/onboarding_widget.dart' show Onboarding, OnboardingState, OnboardingController;
 export 'src/overlay_painter.dart' show OverlayPainter;
 export 'src/step.dart' show OnboardingStep;
 export 'src/stepper.dart' show OnboardingStepper;

--- a/lib/src/overlay_painter.dart
+++ b/lib/src/overlay_painter.dart
@@ -15,6 +15,7 @@ class OverlayPainter extends CustomPainter {
     this.animation,
     this.fullscreen = true,
     this.overlayColor = const Color(0xaa000000),
+    this.margin = EdgeInsets.zero,
   });
 
   /// By default, the value is
@@ -24,6 +25,9 @@ class OverlayPainter extends CustomPainter {
   /// )
   /// ````
   final ShapeBorder shape;
+
+  /// By default, the value is ```EdgeInsets.zero```
+  final EdgeInsets margin;
 
   /// By default, the value is
   /// ```
@@ -56,6 +60,7 @@ class OverlayPainter extends CustomPainter {
       ..close();
 
     final Path holePath = shape.getOuterPath(hole ?? Rect.zero);
+    final Path holeWithMarginPath = shape.getOuterPath(margin.inflateRect(hole ?? Rect.zero));
     final Rect overlayRect =
         EdgeInsets.all(size.width * kOverlayRatio * animation!).inflateRect(
       hole ??
@@ -66,15 +71,29 @@ class OverlayPainter extends CustomPainter {
     );
     final Path overlayPath = overlayShape.getOuterPath(overlayRect);
 
+    // First path. Visible to user
     final Path path = Path.combine(
       PathOperation.difference,
       fullscreen ? canvasPath : overlayPath,
-      holePath,
+      holeWithMarginPath,
+    );
+    // Second path. Fills gap between first path and hole without margin
+    // needed for avoiding user tap registration in this gap
+    final Path secondPath = Path.combine(
+      PathOperation.difference,
+      holeWithMarginPath,
+      holePath
     );
     canvas.drawPath(
       path,
       Paint()
         ..color = overlayColor!
+        ..style = PaintingStyle.fill,
+    );
+    canvas.drawPath(
+      secondPath,
+      Paint()
+        ..color = const Color.fromARGB(0, 0, 0, 0) // transparent color
         ..style = PaintingStyle.fill,
     );
   }

--- a/lib/src/step.dart
+++ b/lib/src/step.dart
@@ -34,6 +34,7 @@ class OnboardingStep {
     this.fullscreen = true,
     this.delay = Duration.zero,
     this.arrowPosition = ArrowPosition.topCenter,
+    this.allowTapThrough = false,
   })  : assert(titleTextColor != null || titleTextStyle != null,
             'You should provide at least one of titleTextColor or titleTextStyle'),
         assert(bodyTextColor != null || bodyTextStyle != null,
@@ -137,6 +138,15 @@ class OnboardingStep {
 
   /// By default, the value used is `Duration.zero`
   final Duration delay;
+
+  /// If ```true``` - taps on selected [focusNode] will be propogated to it (and you 
+  /// have to manually control finishing of step), and taps outside [focusNode]
+  /// will end step.
+  /// 
+  /// If ```false``` - tap to any place will finish this step.
+  /// 
+  /// By default, the value used is ```false```
+  final bool allowTapThrough;
 
   OnboardingStep copyWith({
     FocusNode? focusNode,

--- a/lib/src/stepper.dart
+++ b/lib/src/stepper.dart
@@ -201,7 +201,7 @@ class _OnboardingStepperState extends State<OnboardingStepper>
     holeTween = widgetRect != null
         ? RectTween(
             begin: Rect.zero.shift(widgetRect!.center),
-            end: step.margin.inflateRect(widgetRect!),
+            end: widgetRect!,
           )
         : null;
     overlayColorTween = ColorTween(
@@ -294,7 +294,9 @@ class _OnboardingStepperState extends State<OnboardingStepper>
     final bool isTop = holeRect.center.dy > size.height / 2;
 
     return GestureDetector(
-      behavior: HitTestBehavior.opaque,
+      behavior: step.allowTapThrough 
+        ? HitTestBehavior.deferToChild 
+        : HitTestBehavior.opaque,
       onTap: () {
         nextStep();
       },
@@ -313,6 +315,7 @@ class _OnboardingStepperState extends State<OnboardingStepper>
                 overlayShape: step.overlayShape,
                 center: holeOffset,
                 hole: holeTween?.evaluate(animation),
+                margin: step.margin,
                 animation: animation.value,
                 overlayColor: overlayColorTween.evaluate(animation),
               ),

--- a/lib/src/stepper.dart
+++ b/lib/src/stepper.dart
@@ -48,10 +48,10 @@ class OnboardingStepper extends StatefulWidget {
   final Duration duration;
 
   @override
-  _OnboardingStepperState createState() => _OnboardingStepperState();
+  OnboardingStepperState createState() => OnboardingStepperState();
 }
 
-class _OnboardingStepperState extends State<OnboardingStepper>
+class OnboardingStepperState extends State<OnboardingStepper>
     with SingleTickerProviderStateMixin {
   late int stepperIndex;
   late ColorTween overlayColorTween;


### PR DESCRIPTION
Proposal to add "allow tap through" option in step.

On my project, I need to show user the new feature, we add, and for UX its bad to force user to make one more tap to close tutorial first, and only then make second tap on button to try the feature itself. With this option taps on highlighted focus node will be deferred to child below that overlay' hole.
Disadvantage of this approach, is that we can't track if user tap on this hole, to finish step automatically, and have to manage this by ourself. For this reason I add `OnboardingController` (it also may be used to show and hide onboarding itself, instead of calling Onboarding.of(context) or using GlobalKey) this approach used in Flutter's ListView controller.