### PR TITLE
Guarding overlay remove

### DIFF
--- a/lib/src/onboarding_widget.dart
+++ b/lib/src/onboarding_widget.dart
@@ -146,6 +146,9 @@ class OnboardingState extends State<Onboarding> {
 
   /// Hides the onboarding session overlay
   void hide() {
+    if (!controller.isVisible) {
+      return;
+    }
     _overlayEntry.remove();
     controller.setIsVisible(false);
   }


### PR DESCRIPTION
This is making sure that remove is not called on already removed overlay

It happens if you call `close()` multiple times from the `onTapCallback`.

There are some cases that this is happed even if you have `close()` just one time in the callback