### PR TITLE
Add option to disable animating overlay hole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [3.2.3]
+
+- add: 'animateOverlayHole' property to the OnboardingStep so that the user can
+  control if the overlay hole should be animated or not.
+  (Thanks to [MarcinusX](https://github.com/MarcinusX))
+
 ## [3.2.2]
 
 - fix: Fixing web painting where the hole on the overlay does not get drawn. [#37](https://github.com/talamaska/onboarding_overlay/issues/37)

--- a/README.md
+++ b/README.md
@@ -405,3 +405,5 @@ return MaterialApp(
     `bool`. By default it is `null` and it will use the `LabelPainter`. You can
     use this to draw custom shapes around the hole. You can use the
     `LabelPainter` as a reference
+
+20. **From 3.2.3** [animateOverlayHole] is a property that can be set to `false` to disable the animation of the overlay hole.

--- a/lib/src/step.dart
+++ b/lib/src/step.dart
@@ -83,6 +83,7 @@ class OnboardingStep {
     this.overlayShape = const RoundedRectangleBorder(
       borderRadius: BorderRadius.all(Radius.circular(8.0)),
     ),
+    this.animateOverlayHole = true,
     this.hasLabelBox = false,
     this.labelBoxPadding = const EdgeInsets.all(8.0),
     this.labelBoxDecoration = const BoxDecoration(),
@@ -197,6 +198,11 @@ class OnboardingStep {
   /// ```
   final ShapeBorder overlayShape;
 
+  /// By default, the value used is true
+  ///
+  /// If true, the overlay hole will be animated when the step is shown.
+  final bool animateOverlayHole;
+
   /// This is the space around the `Widget` we want which we would clip a hole
   /// By default, the value is `EdgeInsets.all(8.0)`
   final EdgeInsets margin;
@@ -280,6 +286,7 @@ class OnboardingStep {
     ShapeBorder? shape,
     Color? overlayColor,
     ShapeBorder? overlayShape,
+    bool? animateOverlayHole,
     EdgeInsets? margin,
     EdgeInsets? labelBoxPadding,
     bool? hasLabelBox,
@@ -308,6 +315,7 @@ class OnboardingStep {
       shape: shape ?? this.shape,
       overlayColor: overlayColor ?? this.overlayColor,
       overlayShape: overlayShape ?? this.overlayShape,
+      animateOverlayHole: animateOverlayHole ?? this.animateOverlayHole,
       margin: margin ?? this.margin,
       labelBoxPadding: labelBoxPadding ?? this.labelBoxPadding,
       hasLabelBox: hasLabelBox ?? this.hasLabelBox,
@@ -340,6 +348,7 @@ class OnboardingStep {
       shape: $shape,
       overlayColor: $overlayColor,
       overlayShape: $overlayShape,
+      animateOverlayHole: $animateOverlayHole,
       margin: $margin,
       labelBoxPadding: $labelBoxPadding,
       hasLabelBox: $hasLabelBox,
@@ -374,6 +383,7 @@ class OnboardingStep {
         other.shape == shape &&
         other.overlayColor == overlayColor &&
         other.overlayShape == overlayShape &&
+        other.animateOverlayHole == animateOverlayHole &&
         other.margin == margin &&
         other.labelBoxPadding == labelBoxPadding &&
         other.hasLabelBox == hasLabelBox &&
@@ -404,6 +414,7 @@ class OnboardingStep {
         shape.hashCode ^
         overlayColor.hashCode ^
         overlayShape.hashCode ^
+        animateOverlayHole.hashCode ^
         margin.hashCode ^
         labelBoxPadding.hashCode ^
         hasLabelBox.hashCode ^

--- a/lib/src/stepper.dart
+++ b/lib/src/stepper.dart
@@ -533,7 +533,9 @@ class OnboardingStepperState extends State<OnboardingStepper>
     final double leftPos = _getHorizontalPosition(step, mediaSize, boxWidth);
     final double topPos =
         _getVerticalPosition(step, mediaSize, boxHeight, media);
-    final Rect? holeAnimatedValue = holeTween.evaluate(overlayAnimation);
+    final Rect? holeAnimatedValue = step.animateOverlayHole
+        ? holeTween.evaluate(overlayAnimation)
+        : holeRect;
     final Color? colorAnimatedValue =
         overlayColorTween.evaluate(overlayAnimation);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onboarding_overlay
 description: Flexible to control Onboarding overlay with or without target element (fork from onboard_overlay)
-version: 3.2.2
+version: 3.2.3
 repository: https://github.com/talamaska/onboarding_overlay
 
 environment:


### PR DESCRIPTION
I would love to have an option to disable the animation of the overlay hole. For big widgets, it may look weird if the widget is already rendered. This PR adds this option by adding `animateOverlayHole`, which by default is set to true (therefore no regressions expected).

With  a default `animateOverlayHole: true` (current behavior):
 
https://github.com/user-attachments/assets/8abd4ddc-df5f-4499-a354-49e1a7114053

With changed `animateOverlayHole: false`:

https://github.com/user-attachments/assets/16eacfd7-b19d-4fff-9ea9-4f1055d23d5e


Thank you a lot for this package! I've browsed through a dozen of those, and this one has the best balance of easy API and extensibility. Thank you!