### PR TITLE
Option to customize vertical kSpace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [3.2.4]
+- add: 'labelBoxVerticalDistance' property to the OnboardingStep so that the user can
+  control the space between the label box and the overlay hole. Makes kSpace spacing value customizable.
+  (Thanks to [MarcinusX](https://github.com/MarcinusX))
+
 ## [3.2.3]
 - add: 'labelBoxMargin' property to the OnboardingStep so that the user can
   control the space around the label box. Especially useful for limiting maximum width of the label box.

--- a/README.md
+++ b/README.md
@@ -424,3 +424,15 @@ OnboardingStep(
   ),
 ),
 ```
+
+21. **From 3.2.4**
+- [labelBoxVerticalDistance] property to the OnboardingStep so that the user can customize the space between the label box and the overlay hole.
+
+Example:
+```dart
+OnboardingStep(
+  focusNode: focusNodes[0],
+  titleText: 'Tap anywhere to continue',
+  labelBoxVerticalDistance: 16.0, // default is kSpace = 4.0
+),
+```

--- a/lib/src/step.dart
+++ b/lib/src/step.dart
@@ -87,6 +87,7 @@ class OnboardingStep {
     this.hasLabelBox = false,
     this.labelBoxPadding = const EdgeInsets.all(8.0),
     this.labelBoxMargin = EdgeInsets.zero,
+    this.labelBoxVerticalDistance = kSpace,
     this.labelBoxDecoration = const BoxDecoration(),
     this.hasArrow = false,
     this.fullscreen = true,
@@ -216,6 +217,10 @@ class OnboardingStep {
   /// Space around the label box (outside the decoration box).
   final EdgeInsets labelBoxMargin;
 
+  /// By default, the value is `kSpace = 4.0`
+  /// Vertical space between the label box and the overlay hole.
+  final double labelBoxVerticalDistance;
+
   /// By default, the value is
   /// ```
   /// Color(0x00000000),
@@ -296,6 +301,7 @@ class OnboardingStep {
     EdgeInsets? margin,
     EdgeInsets? labelBoxPadding,
     EdgeInsets? labelBoxMargin,
+    double? labelBoxVerticalDistance,
     bool? hasLabelBox,
     bool? hasArrow,
     bool? fullscreen,
@@ -326,6 +332,8 @@ class OnboardingStep {
       margin: margin ?? this.margin,
       labelBoxPadding: labelBoxPadding ?? this.labelBoxPadding,
       labelBoxMargin: labelBoxMargin ?? this.labelBoxMargin,
+      labelBoxVerticalDistance:
+          labelBoxVerticalDistance ?? this.labelBoxVerticalDistance,
       hasLabelBox: hasLabelBox ?? this.hasLabelBox,
       hasArrow: hasArrow ?? this.hasArrow,
       fullscreen: fullscreen ?? this.fullscreen,
@@ -360,6 +368,7 @@ class OnboardingStep {
       margin: $margin,
       labelBoxPadding: $labelBoxPadding,
       labelBoxMargin: $labelBoxMargin,
+      labelBoxVerticalDistance: $labelBoxVerticalDistance,
       hasLabelBox: $hasLabelBox,
       hasArrow: $hasArrow,
       fullscreen: $fullscreen,
@@ -396,6 +405,7 @@ class OnboardingStep {
         other.margin == margin &&
         other.labelBoxPadding == labelBoxPadding &&
         other.labelBoxMargin == labelBoxMargin &&
+        other.labelBoxVerticalDistance == labelBoxVerticalDistance &&
         other.hasLabelBox == hasLabelBox &&
         other.hasArrow == hasArrow &&
         other.fullscreen == fullscreen &&
@@ -428,6 +438,7 @@ class OnboardingStep {
         margin.hashCode ^
         labelBoxPadding.hashCode ^
         labelBoxMargin.hashCode ^
+        labelBoxVerticalDistance.hashCode ^
         hasLabelBox.hashCode ^
         hasArrow.hashCode ^
         fullscreen.hashCode ^

--- a/lib/src/stepper.dart
+++ b/lib/src/stepper.dart
@@ -348,7 +348,10 @@ class OnboardingStepperState extends State<OnboardingStepper>
     double boxHeight,
     MediaQueryData media,
   ) {
-    final double spacer = step.hasArrow ? kArrowHeight + kSpace : kSpace;
+    double spacer = step.labelBoxVerticalDistance;
+    if (step.hasArrow) {
+      spacer += kArrowHeight;
+    }
 
     if (widgetRect.width != 0 && widgetRect.height != 0) {
       final Rect holeRect = step.margin.inflateRect(widgetRect);
@@ -461,7 +464,7 @@ class OnboardingStepperState extends State<OnboardingStepper>
             mediaSize.height -
                 media.padding.top -
                 media.padding.bottom -
-                2 * kSpace);
+                2 * step.labelBoxVerticalDistance);
       }
     }
     // log('radius ${mediaSize.width * kOverlayRatio}');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: onboarding_overlay
 description: Flexible to control Onboarding overlay with or without target element (fork from onboard_overlay)
-version: 3.2.3
+version: 3.2.4
 repository: https://github.com/talamaska/onboarding_overlay
 
 environment:


### PR DESCRIPTION
Currently the space between the label box and the overlay hole is hardcoded to `kSpace = 4.0` and optional `arrowHeight`.
This PR allows us to customize that value in case we want to have a different vertical distance between the label and the hole. `labelBoxVerticalDistance` defaults to `kSpace` so it doesn't change any current behavior.